### PR TITLE
Zoom breakpoint

### DIFF
--- a/src/app/plugin.ts
+++ b/src/app/plugin.ts
@@ -37,7 +37,8 @@ export class EnchantedCanvasPlugin extends Plugin {
 
 				const canvas = canvasView.canvas;
 				extendCanvas({ canvas, plugin: this });
-
+				canvas.zoomBreakpoint = -100;
+                console.log(canvas.zoomBreakpoint)
 				canvasLoaded({ canvas, file: canvasView.file! });
 			}
 		}, 1000);

--- a/src/entites/canvas/lib.ts
+++ b/src/entites/canvas/lib.ts
@@ -16,6 +16,7 @@ export function extendCanvas({
 	const canvasPrototype = Object.getPrototypeOf(canvas);
 
 	let showCreationMenuProxy: any = null;
+	let zoomBreakpointProxy: any = null;
 
 	const canvasPrototypeProxy = new Proxy(canvasPrototype, {
 		get(target, prop, receiver) {
@@ -33,10 +34,19 @@ export function extendCanvas({
 						return Reflect.apply(target, thisArg, argumentsList);
 					},
 				});
-
 				return showCreationMenuProxy;
 			}
+			if (prop === "zoomBreakpoint") {
+            	return zoomBreakpointProxy ??= target[prop];
+            }
 			return Reflect.get(target, prop, receiver);
+		},
+		set(target, prop, value, receiver) {
+			if (prop === "zoomBreakpoint") {
+				zoomBreakpointProxy = value;
+				return true;
+			}
+			return Reflect.set(target, prop, value, receiver);
 		},
 	});
 


### PR DESCRIPTION
Hello. Great job with the plugin and especially the documentation. 

### Background
I wanted a feature where I could change the breakpoint of the zoom level of the canvas to whatever value I wanted. This is because when we zoom out in a canvas, the actual nodes are replaced by placeholder nodes so no text is visible; and the point at which this happens is pretty fast is what I felt and wanted to configure it.

### Solution Context
- As you said in the docs, there is no API to interact with canvas in Obsidian and especially this property of zoomBreakpoint does not have a setter.
- So I have tried to implement a proxy getter and setter for this property and tried to achieve this goal.

But it does not work and I am struggling to make it work. Any ideas/direction to proceed would be a great help! 